### PR TITLE
fix: update published hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 - id: commit-msg-validate
   name: validate commit message
   description: validate git commit message
-  entry: go run stinker/main.go commit-msg-validate
+  entry: stinker commit-msg-validate
   language: golang
   stages: [commit-msg]
   minimum_pre_commit_version: 4.1.0


### PR DESCRIPTION
This MR updates the published hook to use the tools/CLI name instead of the `go run` command.